### PR TITLE
added trace_id_high for 128 bit TraceID support 

### DIFF
--- a/thrift/zipkinCore.thrift
+++ b/thrift/zipkinCore.thrift
@@ -454,5 +454,9 @@ struct Span {
    * This field is i64 vs i32 to support spans longer than 35 minutes.
    */
   11: optional i64 duration
+  /**
+   * Optional unique 8-byte additional identifier for a trace. If non zero, this
+   * means the trace uses 128 bit traceIds instead of 64 bit.
+   */
+  12: optional i64 trace_id_high
 }
-

--- a/zipkin-api.yaml
+++ b/zipkin-api.yaml
@@ -268,9 +268,9 @@ definitions:
         description: 'Parent span id. 8-byte identifier encoded as 16 lowercase hex characters.  Can be ommitted or set to nil if span is the root span of a trace.'
       id:
         type: string
-        maxLength: 16
+        maxLength: 32
         minLength: 16
-        description: 'Id of current span, unique in context of traceId.  8-byte identifier encoded as 16 lowercase hex characters.'
+        description: 'Id of current span, unique in context of traceId. 8-byte or 16-byte identifier respectively encoded as 16 or 32 lowercase hex characters.'
       timestamp:
         type: integer
         format: int64


### PR DESCRIPTION
added optional trace_id_high property to Span struct for 128bit span support. 
updated yaml doc for json encoding

@adriancole is the explanation in the yaml correct for the Span's `id` property in case of JSON encoding? 