### PR TITLE
quote response status codes to make them json compatible

### DIFF
--- a/zipkin-api.yaml
+++ b/zipkin-api.yaml
@@ -21,13 +21,13 @@ paths:
       description: |
         Returns a list of all service names associated with annotations.
       responses:
-        200:
+        '200':
           description: Succes
           schema:
             type: array
             items:
               type: string
-        400:
+        '400':
           description: Bad Request Error
   /spans:
     get:
@@ -41,13 +41,13 @@ paths:
           trace. The /services endpoint enumerates possible input values.
         type: string
       responses:
-        200:
+        '200':
           description: OK
           schema:
             type: array
             items:
               type: string
-        400:
+        '400':
           description: Bad Request Error
     post:
       description: |
@@ -65,7 +65,7 @@ paths:
           schema:
             $ref: "#/definitions/ListOfSpans"
       responses:
-        202:
+        '202':
           description: Accepted
   /traces:
     get:
@@ -141,7 +141,7 @@ paths:
           description: |
             Maximum number of traces to return. Defaults to 10
       responses:
-        200:
+        '200':
           description: OK
           schema:
             $ref: "#/definitions/ListOfTraces"
@@ -167,11 +167,11 @@ paths:
             adjusters. For example, this might explain or rule out clock skew.
           type: boolean
       responses:
-        200:
+        '200':
           description: OK
           schema:
             $ref: "#/definitions/Trace"
-        404:
+        '404':
           description: "`traceId` not found"
   /dependencies:
     get:
@@ -198,7 +198,7 @@ paths:
           type: integer
           format: int64
       responses:
-        200:
+        '200':
           description: OK
           schema:
             type: array

--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -17,13 +17,13 @@ paths:
       description: |
         Returns a list of all service names associated with span endpoints.
       responses:
-        200:
+        '200':
           description: Succes
           schema:
             type: array
             items:
               type: string
-        400:
+        '400':
           description: Bad Request Error
   /spans:
     get:
@@ -37,13 +37,13 @@ paths:
           graph. The /services endpoint enumerates possible input values.
         type: string
       responses:
-        200:
+        '200':
           description: OK
           schema:
             type: array
             items:
               type: string
-        400:
+        '400':
           description: Bad Request Error  
     post:
       description: |
@@ -59,7 +59,7 @@ paths:
           schema:
             $ref: "#/definitions/ListOfSpans"
       responses:
-        202:
+        '202':
           description: Accepted
   /traces:
     get:
@@ -134,7 +134,7 @@ paths:
           description: |
             Maximum number of traces to return. Defaults to 10
       responses:
-        200:
+        '200':
           description: OK
           schema:
             $ref: "#/definitions/ListOfTraces"
@@ -154,11 +154,11 @@ paths:
                       Encoded as 16 or 32 lowercase hex characters corresponding to 64 or 128 bits.
                       For example, a 128bit trace ID looks like 4e441824ec2b6a44ffdc9bb9a6453df3
       responses:
-        200:
+        '200':
           description: OK
           schema:
             $ref: "#/definitions/Trace"
-        404:
+        '404':
           description: "`traceId` not found"
   /dependencies:
     get:
@@ -182,7 +182,7 @@ paths:
           type: integer
           format: int64
       responses:
-        200:
+        '200':
           description: OK
           schema:
             type: array


### PR DESCRIPTION
swagger supports json, but yaml is much more flexible than json. It allows numeric keys, unlike json.

I'm actually not 100% sure whether this explanation is correct, or whether it is actually an implementation issue, but it definitely fails in python with pyyaml and jsonschema validation.

repro using [bravado-core](https://github.com/Yelp/bravado-core):
```python
import yaml
from bravado_core.spec import Spec
Spec.from_dict(yaml.load(open('/path/to/zipkin-api.yaml'))) # throws jsonschema exception
```