### PR TITLE
Adds proto3 definition

### DIFF
--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -208,13 +208,13 @@ definitions:
         format: ipv4
         description: |
                     The text representation of the primary IPv4 address associated with this
-                    a connection. Ex. 192.168.99.100 Absent if unknown.
+                    connection. Ex. 192.168.99.100 Absent if unknown.
       ipv6:
         type: string
         format: ipv6
         description: |
-                    The text representation of the primary IPv6 address associated with this
-                    a connection. Ex. 2001:db8::c001 Absent if unknown.
+                    The text representation of the primary IPv6 address associated with a
+                    connection. Ex. 2001:db8::c001 Absent if unknown.
                     
                     Prefer using the ipv4 field for mapped addresses.
       port:
@@ -279,6 +279,21 @@ definitions:
       $ref: "#/definitions/Trace"      
   Span:
     title: Span
+    description: |
+                A span is a single-host view of an operation. A trace is a series of spans
+                (often RPC calls) which nest to form a latency tree. Spans are in the same
+                trace when they share the same trace ID. The parent_id field establishes the
+                position of one span in the tree.
+                 
+                The root span is where parent_id is Absent and usually has the longest
+                duration in the trace. However, nested asynchronous work can materialize as
+                child spans whose duration exceed the root span.
+                 
+                Spans usually represent remote activity such as RPC calls, or messaging
+                producers and consumers. However, they can also represent in-process
+                activity in any position of the trace. For example, a root span could
+                represent a server receiving an initial client request. A root span could
+                also represent a scheduled job that has no remote context.
     type: object
     required:
       - traceId
@@ -325,37 +340,39 @@ definitions:
           - PRODUCER
           - CONSUMER
         description: |
-                    When present, clarifies timestamp, duration and remoteEndpoint. When
-                    absent, the span is local or incomplete. Unlike client and server,
-                    there is no direct critical path latency relationship between producer
-                    and consumer spans.
+                    When present, kind clarifies timestamp, duration and remoteEndpoint. When
+                    absent, the span is local or incomplete. Unlike client and server, there
+                    is no direct critical path latency relationship between producer and
+                    consumer spans.
                     
                     * `CLIENT`
-                      * timestamp - The moment a request was sent (formerly "cs")
-                      * duration - When present indicates when a response was received (formerly "cr")
-                      * remoteEndpoint - Represents the server. Leave serviceName absent if unknown.
+                      * timestamp is the moment a request was sent to the server. (in v1 "cs")
+                      * duration is the delay until a response or an error was received. (in v1 "cr"-"cs")
+                      * remoteEndpoint is the server. (in v1 "sa")
                     * `SERVER`
-                      * timestamp - The moment a request was received (formerly "sr")
-                      * duration - When present indicates when a response was sent (formerly "ss")
-                      * remoteEndpoint - Represents the client. Leave serviceName absent if unknown.
+                      * timestamp is the moment a client request was received. (in v1 "sr")
+                      * duration is the delay until a response was sent or an error. (in v1 "ss"-"sr")
+                      * remote_endpoint is the client. (in v1 "ca")
                     * `PRODUCER`
-                      * timestamp - The moment a message was sent to a destination (formerly "ms")
-                      * duration - When present represents delay sending the message, such as batching.
-                      * remoteEndpoint - Represents the broker. Leave serviceName absent if unknown.
+                      * timestamp is the moment a message was sent to a destination. (in v1  "ms")
+                      * duration is the delay sending the message, such as batching.
+                      * remoteEndpoint is the broker.
                     * `CONSUMER`
-                      * timestamp - The moment a message was received from an origin (formerly "mr")
-                      * duration - When present represents delay consuming the message, such as from backlog.
+                      * timestamp is the moment a message was received from an origin. (in v1 "mr")
+                      * duration is the delay consuming the message, such as from backlog.
                       * remoteEndpoint - Represents the broker. Leave serviceName absent if unknown.
       timestamp:
         type: integer
         format: int64
         description: |
-                    Epoch **microseconds** of the start of this span, possibly absent if incomplete.
+                    Epoch microseconds of the start of this span, possibly absent if
+                    incomplete.
                     
                     For example, 1502787600000000 corresponds to 2017-08-15 09:00 UTC
                     
-                    This value should be set directly by instrumentation, using the most precise
-                    value possible. For example, gettimeofday or multiplying epoch millis by 1000.
+                    This value should be set directly by instrumentation, using the most
+                    precise value possible. For example, gettimeofday or multiplying epoch
+                    millis by 1000.
                     
                     There are three known edge-cases where this could be reported absent.
                      * A span was allocated but never started (ex not yet received a timestamp)
@@ -367,7 +384,8 @@ definitions:
         minimum: 1
         description: |
                     Duration in **microseconds** of the critical path, if known. Durations of less
-                    than one are rounded up. Duration of children can be longer than their parents
+                    than one are rounded up. Duration of children can be longer than their
+                    parents
                     due to asynchronous operations.
                     
                     For example 150 milliseconds is 150000 microseconds.
@@ -385,17 +403,20 @@ definitions:
         description: |
                     The host that recorded this span, primarily for query by service name.
                     
-                    Instrumentation should always record this. Usually, absent implies late data.
-                    The IP address corresponding to this is usually the site local or advertised
-                    service address. When present, the port indicates the listen port.
+                    Instrumentation should always record this. Usually, absent implies late
+                    data. The IP address corresponding to this is usually the site local or
+                    advertised service address. When present, the port indicates the listen
+                    port.
       remoteEndpoint:
         $ref: "#/definitions/Endpoint"
         description: |
-                    When an RPC (or messaging) span, indicates the other side of the connection.
+                    When an RPC (or messaging) span, indicates the other side of the
+                    connection.
                     
-                    By recording the remote endpoint, your trace will contain network context even
-                    if the peer is not tracing. For example, you can record the IP from the
-                    `X-Forwarded-For` header or the service name and socket of a remote peer.
+                    By recording the remote endpoint, your trace will contain network context
+                    even if the peer is not tracing. For example, you can record the IP from
+                    the `X-Forwarded-For` header or the service name and socket of a remote
+                    peer.
       annotations:
         type: array
         uniqueItems: true

--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -385,8 +385,7 @@ definitions:
         description: |
                     Duration in **microseconds** of the critical path, if known. Durations of less
                     than one are rounded up. Duration of children can be longer than their
-                    parents
-                    due to asynchronous operations.
+                    parents due to asynchronous operations.
                     
                     For example 150 milliseconds is 150000 microseconds.
       debug:

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package zipkin2.proto3;
+
+option java_multiple_files = true;
+
+message Span {
+  // 8 or 16 bytes required
+  bytes trace_id = 1;
+  // 8 bytes optional
+  bytes parent_id = 2;
+  // 8 bytes required
+  bytes id = 3;
+  enum Kind {
+    KIND_UNSPECIFIED = 0;
+    SERVER = 1;
+    CLIENT = 2;
+    PRODUCER = 3;
+    CONSUMER = 4;
+  }
+  Kind kind = 4;
+  string name = 5;
+  uint64 timestamp = 6;
+  uint64 duration = 7;
+  Endpoint local_endpoint = 8;
+  Endpoint remote_endpoint = 9;
+  repeated Annotation annotations = 10;
+  map<string, string> tags = 11;
+  bool debug = 12;
+  bool shared = 13;
+}
+
+message Endpoint {
+  string service_name = 4;
+  // 4 bytes
+  bytes ipv4 = 1;
+  // 16 bytes
+  bytes ipv6 = 3;
+  // technically uint16 would work, but there is none
+  int32 port = 2;
+}
+
+message Annotation {
+  uint64 timestamp = 5;
+  string value = 1;
+}
+

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -23,8 +23,8 @@ message Span {
   bytes id = 3;
   enum Kind {
     KIND_UNSPECIFIED = 0;
-    SERVER = 1;
-    CLIENT = 2;
+    CLIENT = 1;
+    SERVER = 2;
     PRODUCER = 3;
     CONSUMER = 4;
   }

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -64,11 +64,3 @@ message Annotation {
 message ListOfSpans {
   repeated Span spans = 1;
 }
-
-message DependencyLink {
-  string parent = 1;
-  string child = 2;
-  uint64 call_count = 3;
-  uint64 error_count = 4;
-}
-

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -4,6 +4,14 @@ package zipkin2.proto3;
 
 option java_multiple_files = true;
 
+// Epoch timestamp are encoded fixed64 are varint would also be 8 bytes, and more
+// expensive to encode and size. Duration is stored uint64, as often the numbers
+// are quite small.
+//
+// Default values are ok, as only natural numbers are used. For example, zero is
+// an invalid timestamp and an invalid duration, false values for debug or sampled
+// are ignorable, and zero-length strings also coerce to null.
+//
 // Note fields up to 15 take 1 byte to encode. Take care when adding new fields
 // https://developers.google.com/protocol-buffers/docs/proto3#assigning-tags
 message Span {
@@ -22,7 +30,7 @@ message Span {
   }
   Kind kind = 4;
   string name = 5;
-  uint64 timestamp = 6;
+  fixed64 timestamp = 6;
   uint64 duration = 7;
   Endpoint local_endpoint = 8;
   Endpoint remote_endpoint = 9;
@@ -43,7 +51,7 @@ message Endpoint {
 }
 
 message Annotation {
-  uint64 timestamp = 1;
+  fixed64 timestamp = 1;
   string value = 2;
 }
 

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -9,7 +9,7 @@ option java_multiple_files = true;
 // are quite small.
 //
 // Default values are ok, as only natural numbers are used. For example, zero is
-// an invalid timestamp and an invalid duration, false values for debug or sampled
+// an invalid timestamp and an invalid duration, false values for debug or shared
 // are ignorable, and zero-length strings also coerce to null.
 //
 // Note fields up to 15 take 1 byte to encode. Take care when adding new fields

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -4,7 +4,24 @@ package zipkin2.proto3;
 
 option java_multiple_files = true;
 
-// Epoch timestamp are encoded fixed64 are varint would also be 8 bytes, and more
+// A span is a single-host view of an operation. A trace is a series of spans
+// (often RPC calls) which nest to form a latency tree. Spans are in the same
+// trace when they share the same trace ID. The parent_id field establishes the
+// position of one span in the tree.
+//
+// The root span is where parent_id is Absent and usually has the longest
+// duration in the trace. However, nested asynchronous work can materialize as
+// child spans whose duration exceed the root span.
+//
+// Spans usually represent remote activity such as RPC calls, or messaging
+// producers and consumers. However, they can also represent in-process
+// activity in any position of the trace. For example, a root span could
+// represent a server receiving an initial client request. A root span could
+// also represent a scheduled job that has no remote context.
+//
+// Encoding notes:
+//
+// Epoch timestamp are encoded fixed64 as varint would also be 8 bytes, and more
 // expensive to encode and size. Duration is stored uint64, as often the numbers
 // are quite small.
 //
@@ -12,46 +29,160 @@ option java_multiple_files = true;
 // an invalid timestamp and an invalid duration, false values for debug or shared
 // are ignorable, and zero-length strings also coerce to null.
 //
+// The next id is 14.
+//
 // Note fields up to 15 take 1 byte to encode. Take care when adding new fields
 // https://developers.google.com/protocol-buffers/docs/proto3#assigning-tags
 message Span {
-  // 8 or 16 bytes required
+  // Randomly generated, unique identifier for a trace, set on all spans within
+  // it.
+  //
+  // This field is required and encoded as 8 or 16 opaque bytes.
   bytes trace_id = 1;
-  // 8 bytes optional
+  // The parent span ID or absent if this the root span in a trace.
   bytes parent_id = 2;
-  // 8 bytes required
+  // Unique identifier for this operation within the trace.
+  //
+  // This field is required and encoded as 8 opaque bytes.
   bytes id = 3;
+  // When present, kind clarifies timestamp, duration and remote_endpoint. When
+  // absent, the span is local or incomplete. Unlike client and server, there
+  // is no direct critical path latency relationship between producer and
+  // consumer spans.
   enum Kind {
-    KIND_UNSPECIFIED = 0;
+    // Default value interpreted as absent.
+    SPAN_KIND_UNSPECIFIED = 0;
+    // The span represents the client side of an RPC operation, implying the
+    // following:
+    //
+    // timestamp is the moment a request was sent to the server.
+    // duration is the delay until a response or an error was received.
+    // remote_endpoint is the server.
     CLIENT = 1;
+    // The span represents the server side of an RPC operation, implying the
+    // following:
+    //
+    // timestamp is the moment a client request was received.
+    // duration is the delay until a response was sent or an error.
+    // remote_endpoint is the client.
     SERVER = 2;
+    // The span represents production of a message to a remote broker, implying
+    // the following:
+    //
+    // timestamp is the moment a message was sent to a destination.
+    // duration is the delay sending the message, such as batching.
+    // remote_endpoint is the broker.
     PRODUCER = 3;
+    // The span represents consumption of a message from a remote broker, not
+    // time spent servicing it. For example, a message processor would be an
+    // in-process child span of a consumer. Consumer spans imply the following:
+    //
+    // timestamp is the moment a message was received from an origin.
+    // duration is the delay consuming the message, such as from backlog.
+    // remote_endpoint is the broker.
     CONSUMER = 4;
   }
+  // When present, used to interpret remote_endpoint
   Kind kind = 4;
+  // The logical operation this span represents in lowercase (e.g. rpc method).
+  // Leave absent if unknown.
+  //
+  // As these are lookup labels, take care to ensure names are low cardinality.
+  // For example, do not embed variables into the name.
   string name = 5;
+  // Epoch microseconds of the start of this span, possibly absent if
+  // incomplete.
+  //
+  // For example, 1502787600000000 corresponds to 2017-08-15 09:00 UTC
+  //
+  // This value should be set directly by instrumentation, using the most
+  // precise value possible. For example, gettimeofday or multiplying epoch
+  // millis by 1000.
+  //
+  // There are three known edge-cases where this could be reported absent.
+  // - A span was allocated but never started (ex not yet received a timestamp)
+  // - The span's start event was lost
+  // - Data about a completed span (ex tags) were sent after the fact
   fixed64 timestamp = 6;
+  // Duration in microseconds of the critical path, if known. Durations of less
+  // than one are rounded up. Duration of children can be longer than their
+  // parents due to asynchronous operations.
+  //
+  // For example 150 milliseconds is 150000 microseconds.
   uint64 duration = 7;
+  // The host that recorded this span, primarily for query by service name.
+  //
+  // Instrumentation should always record this. Usually, absent implies late
+  // data. The IP address corresponding to this is usually the site local or
+  // advertised service address. When present, the port indicates the listen
+  // port.
   Endpoint local_endpoint = 8;
+  // When an RPC (or messaging) span, indicates the other side of the
+  // connection.
+  //
+  // By recording the remote endpoint, your trace will contain network context
+  // even if the peer is not tracing. For example, you can record the IP from
+  // the "X-Forwarded-For" header or the service name and socket of a remote
+  // peer.
   Endpoint remote_endpoint = 9;
+  // Associates events that explain latency with the time they happened.
   repeated Annotation annotations = 10;
+  // Tags give your span context for search, viewing and analysis.
+  //
+  // For example, a key "your_app.version" would let you lookup traces by
+  // version. A tag "sql.query" isn't searchable, but it can help in debugging
+  // when viewing a trace.
   map<string, string> tags = 11;
+  // True is a request to store this span even if it overrides sampling policy.
+  //
+  // This is true when the "X-B3-Flags" header has a value of 1.
   bool debug = 12;
+  // True if we are contributing to a span started by another tracer (ex on a
+  // different host).
   bool shared = 13;
 }
 
+// The network context of a node in the service graph.
+//
+// The next id is 5.
 message Endpoint {
+  // Lower-case label of this node in the service graph, such as "favstar".
+  // Leave absent if unknown.
+  //
+  // This is a primary label for trace lookup and aggregation, so it should be
+  // intuitive and consistent. Many use a name from service discovery.
   string service_name = 1;
-  // 4 bytes
+  // 4 byte representation of the primary IPv4 address associated with this
+  // connection. Absent if unknown.
   bytes ipv4 = 2;
-  // 16 bytes
+  // 16 byte representation of the primary IPv6 address associated with this
+  // connection. Absent if unknown.
+  //
+  // Prefer using the ipv4 field for mapped addresses.
   bytes ipv6 = 3;
-  // technically uint16 would work, but there is none
+  // Depending on context, this could be a listen port or the client-side of a
+  // socket. Absent if unknown.
   int32 port = 4;
 }
 
+// Associates an event that explains latency with a timestamp.
+// Unlike log statements, annotations are often codes. Ex. "ws" for WireSend
+//
+// The next id is 3.
 message Annotation {
+  // Epoch microseconds of this event.
+  //
+  // For example, 1502787600000000 corresponds to 2017-08-15 09:00 UTC
+  //
+  // This value should be set directly by instrumentation, using the most
+  // precise value possible. For example, gettimeofday or multiplying epoch
+  // millis by 1000.
   fixed64 timestamp = 1;
+  // Usually a short tag indicating an event, like "error"
+  //
+  // While possible to add larger data, such as garbage collection details, low
+  // cardinality event names both keep the size of spans down and also are easy
+  // to search against.
   string value = 2;
 }
 
@@ -60,7 +191,7 @@ message Annotation {
 // This is used for all transports: POST, Kafka messages etc. No other fields
 // are expected, This message facilitates the mechanics of encoding a list, as
 // a field number is required. The name of this type is the same in the OpenApi
-// aka Swagger specification.
+// aka Swagger specification. https://zipkin.io/zipkin-api/#/default/post_spans
 message ListOfSpans {
   repeated Span spans = 1;
 }

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -55,3 +55,20 @@ message Annotation {
   string value = 2;
 }
 
+// A list of spans with possibly different trace ids, in no particular order.
+//
+// This is used for all transports: POST, Kafka messages etc. No other fields
+// are expected, This message facilitates the mechanics of encoding a list, as
+// a field number is required. The name of this type is the same in the OpenApi
+// aka Swagger specification.
+message ListOfSpans {
+  repeated Span spans = 1;
+}
+
+message DependencyLink {
+  string parent = 1;
+  string child = 2;
+  uint64 call_count = 3;
+  uint64 error_count = 4;
+}
+

--- a/zipkin2.proto
+++ b/zipkin2.proto
@@ -4,6 +4,8 @@ package zipkin2.proto3;
 
 option java_multiple_files = true;
 
+// Note fields up to 15 take 1 byte to encode. Take care when adding new fields
+// https://developers.google.com/protocol-buffers/docs/proto3#assigning-tags
 message Span {
   // 8 or 16 bytes required
   bytes trace_id = 1;
@@ -31,17 +33,17 @@ message Span {
 }
 
 message Endpoint {
-  string service_name = 4;
+  string service_name = 1;
   // 4 bytes
-  bytes ipv4 = 1;
+  bytes ipv4 = 2;
   // 16 bytes
   bytes ipv6 = 3;
   // technically uint16 would work, but there is none
-  int32 port = 2;
+  int32 port = 4;
 }
 
 message Annotation {
-  uint64 timestamp = 5;
-  string value = 1;
+  uint64 timestamp = 1;
+  string value = 2;
 }
 


### PR DESCRIPTION
Design notes:

This is just like json, except uses bytes for IDs and IPs and enum instead of string for span kind

When finished will fix #39