### PR TITLE
Clarifies trace ID is encoded in big-endian byte order

### DIFF
--- a/zipkin-api.yaml
+++ b/zipkin-api.yaml
@@ -151,7 +151,7 @@ paths:
         - name: traceId
           in: path
           required: true
-          description: the 64 or 128-bit hex-encoded id of the trace as a path parameter.
+          description: the 64 or 128-bit big endian, hex-encoded id of the trace as a path parameter.
           type: string
         - name: raw
           in: query
@@ -335,7 +335,8 @@ definitions:
         description: |
                     Randomly generated, unique identifier for a trace, set on all spans within it.
                     
-                    Encoded as 16 or 32 lowercase hex characters corresponding to 64 or 128 bits.
+                    Encoded as 16 or 32 lowercase hex characters in big endian byte order,
+                    corresponding to 64 or 128 bits,
                     For example, a 128bit trace ID looks like 4e441824ec2b6a44ffdc9bb9a6453df3
       name:
         type: string

--- a/zipkin.proto
+++ b/zipkin.proto
@@ -53,7 +53,8 @@ message Span {
   // Randomly generated, unique identifier for a trace, set on all spans within
   // it.
   //
-  // This field is required and encoded as 8 or 16 opaque bytes.
+  // This field is required and encoded as 8 or 16 bytes, in big endian byte
+  // order.
   bytes trace_id = 1;
   // The parent span ID or absent if this the root span in a trace.
   bytes parent_id = 2;


### PR DESCRIPTION
@basvanbeek noticed we don't explicitly indicate byte order even if it
is implied in other scenarios such as downgrading of trace IDs. This
makes the trace ID byte order explicit.