### PR TITLE
Fixes three Zipkin v2 swagger2 datatypes

### DIFF
--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019 The OpenZipkin Authors
+# Copyright 2018-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -115,12 +115,14 @@ paths:
         - name: minDuration
           in: query
           type: integer
+          format: int64
           description: |
              Ex. 100000 (for 100ms). Only return traces whose `Span.duration` is
              greater than or equal to minDuration microseconds.
         - name: maxDuration
           in: query
           type: integer
+          format: int64
           description: |
             Only return traces whose Span.duration is less than or equal to
             `maxDuration` microseconds. Only valid with minDuration.

--- a/zipkin2-api.yaml
+++ b/zipkin2-api.yaml
@@ -317,6 +317,7 @@ definitions:
     properties:
       timestamp:
         type: integer
+        format: int64
         description: |
                     Epoch **microseconds** of this event.
 


### PR DESCRIPTION
This PR allows some client generators (such as nswag) to select the correct data type for microseconds when either:
1. querying for spans, or
2. de-serializing timestamps in annotations

This PR author is not sure if all client or server generators behave the same. For those that have never queried for a long span and weren't otherwise having problems this could break something somewhere for someone even though it improves zipkin-api.