### PR TITLE
Removes the TopBar form

### DIFF
--- a/swagger-initializer.js
+++ b/swagger-initializer.js
@@ -1,14 +1,15 @@
 window.onload = function() {
   //<editor-fold desc="Changeable Configuration Block">
 
-  // the following lines will be replaced by docker/configurator, when it runs in a docker-container
+  // Changes from defaults include the url and skipping the first standalone
+  // preset, as that loads the TopBar which has XSS problems.
   window.ui = SwaggerUIBundle({
     url: "https://zipkin.io/zipkin-api/zipkin2-api.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
       SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
+      SwaggerUIStandalonePreset.slice(1) // index zero is the TopBar
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl

--- a/swagger-initializer.js
+++ b/swagger-initializer.js
@@ -1,19 +1,21 @@
-window.onload = function() {
+window.onload = function () {
   //<editor-fold desc="Changeable Configuration Block">
 
   // Changes from defaults include the url and skipping the first standalone
-  // preset, as that loads the TopBar which has XSS problems.
+  // preset, as that loads the TopBar. We don't need to load arbitrary API
+  // definitions and forms increase the XSS attack surface.
   window.ui = SwaggerUIBundle({
     url: "https://zipkin.io/zipkin-api/zipkin2-api.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset.slice(1) // index zero is the TopBar
+        SwaggerUIBundle.presets.apis,
+
+      // Retain defaults, except index zero, which is the TopBar.
+      // https://github.com/swagger-api/swagger-ui/blob/v5.11.8/src/standalone/presets/standalone/index.js#L10
+      SwaggerUIStandalonePreset.slice(1)
     ],
-    plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
-    ],
+    plugins: [SwaggerUIBundle.plugins.DownloadUrl],
     layout: "StandaloneLayout"
   });
 


### PR DESCRIPTION
This removes the TopBar form, which removes any problems around it. Our doc page is only for our current API.

Note, this doesn't need any custom build to accomplish, just a (non-intuitive) change to swagger-initializer.js. I found out about this by searching issues in github and several are doing the same thing.

As this change is against the gh-pages branch, I can't also update build-bin/README.md on master. I'll do that in a separate PR once it is verified to fix the issue.

Later, we can make GH automation to regenerate the dist by unzipping the swagger dist overwriting everything except our IDL and swagger-initializer.js.

Before:
![Screenshot 2024-03-03 at 11 16 44](https://github.com/openzipkin/zipkin-api/assets/64215/9cdf3113-794e-4b20-8db2-498645adf82e)

Now:
![Screenshot 2024-03-03 at 11 17 31](https://github.com/openzipkin/zipkin-api/assets/64215/0e7cab6f-235b-4763-bb2d-0545d8e3e407)

